### PR TITLE
Wrong name of Kafka Topic defined in BeerGenerator

### DIFF
--- a/documentation/modules/ROOT/pages/kafka-and-streams.adoc
+++ b/documentation/modules/ROOT/pages/kafka-and-streams.adoc
@@ -139,7 +139,7 @@ public class BeerGenerator {
     @RestClient
     BeerService service;
 
-    @Outgoing("beers")
+    @Outgoing("beer")
     Multi<String> beers() {
         List<Beer>  beers = service.getBeers(10);
         return Multi.createFrom().ticks().every(Duration.ofSeconds(1)) //<1>


### PR DESCRIPTION
The price-generator container is subscribed to topic "beer", but the source code is sending data to topic "beers". Just fixing the "@Outgoing" to send the data to the right topic will fix everything.