### PR TITLE
Fix for CertificateException when using www in fruityvice url

### DIFF
--- a/documentation/modules/ROOT/pages/fault-tolerance.adoc
+++ b/documentation/modules/ROOT/pages/fault-tolerance.adoc
@@ -100,7 +100,7 @@ curl localhost:8080/fruit?season=Summer
 ]
 ----
 
-No change from calls done previously, but now switch off your network so you do not have access to http://www.fruityvice.com.
+No change from calls done previously, but now switch off your network so you do not have access to http://fruityvice.com.  
 
 Run the following command again:
 
@@ -110,7 +110,7 @@ Run the following command again:
 curl localhost:8080/fruit?season=Summer
 ----
 
-Now after waiting 6 seconds (3 retries x 2 seconds), the next exception is thrown `java.net.UnknownHostException: www.fruityvice.com`.
+Now after waiting 6 seconds (3 retries x 2 seconds), the next exception is thrown `java.net.UnknownHostException: fruityvice.com`.
 
 == Add Fallback to Fruity Vice Service
 
@@ -248,7 +248,7 @@ Run the following command at least 5 times:
 curl localhost:8080/fruit?season=Summer
 ----
 
-The output changes from `java.net.UnknownHostException: www.fruityvice.com` (or any other network exception) in the first calls to `org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException: getFruitByName` when the circuit is opened.
+The output changes from `java.net.UnknownHostException: fruityvice.com` (or any other network exception) in the first calls to `org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException: getFruitByName` when the circuit is opened.
 
 The big difference between the first exception and the second one is that the first one occurs because the circuit is closed while the system is trying to reach the host, while in the second one, the circuit is closed and the exception is thrown automatically without trying to reach the host.
 

--- a/documentation/modules/ROOT/pages/health.adoc
+++ b/documentation/modules/ROOT/pages/health.adoc
@@ -102,7 +102,7 @@ Some extensions may provide default health checks, including that the extension 
 For example, quarkus-agroal (that is used to manage Quarkus datasources) automatically registers a readiness health check that will validate each datasource.
 
 Since the readiness of the database is already assessed just by adding those extensions, we should look into defining health checks for other dependencies that we have.
-As we depend on the availability of https://www.fruityvice.com, let's create a new `ReadinessProbe` to assess its availability prior to using it.
+As we depend on the availability of https://fruityvice.com, let's create a new `ReadinessProbe` to assess its availability prior to using it.
 
 We will define a new Java class in `src/main/java` in the `com.redhat.developers` package with the following contents:
 
@@ -161,7 +161,7 @@ curl localhost:8080/health
             "name": "ExternalURL health check",
             "status": "UP",
             "data": {
-                "host": "GET https://www.fruityvice.com/api/fruit/banana"
+                "host": "GET https://fruityvice.com/api/fruit/banana"
             }
         },
         {
@@ -220,7 +220,7 @@ curl localhost:8080/health/ready
             "name": "ExternalURL health check",
             "status": "UP",
             "data": {
-                "host": "GET https://www.fruityvice.com/api/fruit/banana"
+                "host": "GET https://fruityvice.com/api/fruit/banana"
             }
         },
         {

--- a/documentation/modules/ROOT/pages/rest-client.adoc
+++ b/documentation/modules/ROOT/pages/rest-client.adoc
@@ -2,7 +2,7 @@
 
 An atypical scenario in a Microservices architecture is the remote invocation of remote REST HTTP endpoints. Quarkus provides a typed REST client that follows the  https://github.com/eclipse/microprofile-rest-client[MicroProfile REST Client, window=_blank] specification.
 
-Let's create a REST client that accesses https://www.fruityvice.com[window=_blank] to get nutrition information about our fruits. The endpoint we're interested in is this one:
+Let's create a REST client that accesses https://fruityvice.com[window=_blank] to get nutrition information about our fruits. The endpoint we're interested in is this one:
 
 * `api/fruit/\{name\}`, which returns specific info about the given fruit name.
 
@@ -74,7 +74,7 @@ quarkus extension add quarkus-rest-client
 
 == Create FruityVice POJO
 
-We need to create a POJO object that is used to unmarshal a JSON message from http://www.fruityvice.com[window=_blank].
+We need to create a POJO object that is used to unmarshal a JSON message from http://fruityvice.com[window=_blank].
 
 Create a new `FruityVice` Java class in `src/main/java` in the `com.redhat.developers` package with the following contents:
 
@@ -176,7 +176,7 @@ Add the following properties to your `application.properties` in `src/main/resou
 [.console-input]
 [source,properties]
 ----
-com.redhat.developers.FruityViceService/mp-rest/url=https://www.fruityvice.com
+com.redhat.developers.FruityViceService/mp-rest/url=https://fruityvice.com
 ----
 
 == Create FruitDTO


### PR DESCRIPTION
Seems like the FruityVice's service's certificate is only valid for https://fruityvice.com and not for https://www.fruityvice.com so fixing the url in the tutorial to avoid running into cert errors.