### PR TITLE
Added a missing comma to the 'quarkus:add-extension' command

### DIFF
--- a/documentation/modules/ROOT/pages/rest-client.adoc
+++ b/documentation/modules/ROOT/pages/rest-client.adoc
@@ -268,6 +268,7 @@ public class FruitResource {
 
 
     @RestClient
+    @Inject
     FruityViceService fruityViceService;
 
     @Transactional

--- a/documentation/modules/ROOT/pages/spring.adoc
+++ b/documentation/modules/ROOT/pages/spring.adoc
@@ -14,7 +14,7 @@ Maven::
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-mvn quarkus:add-extension -Dextensions=quarkus-spring-web,quarkus-spring-data-jpa quarkus-resteasy-jackson
+mvn quarkus:add-extension -Dextensions=quarkus-spring-web,quarkus-spring-data-jpa,quarkus-resteasy-jackson
 ----
 
 --


### PR DESCRIPTION
A small fix that was breaking the "Spring Compatibility" section in the tutorial.