### PR TITLE
Move away from resteasy to resteasy-reactive extension

### DIFF
--- a/documentation/modules/ROOT/pages/_partials/compile-and-run.adoc
+++ b/documentation/modules/ROOT/pages/_partials/compile-and-run.adoc
@@ -131,8 +131,8 @@ __  ____  __  _____   ___  __ ____  ______
  --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
  -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
-2023-05-03 18:17:48,400 INFO  [io.quarkus] (Quarkus Main Thread) tutorial-app 1.0-SNAPSHOT on JVM (powered by Quarkus 3.1.2.Final) started in 0.394s. Listening on: http://localhost:8080
+INFO  [io.quarkus] (Quarkus Main Thread) tutorial-app 1.0-SNAPSHOT on JVM (powered by Quarkus 3.1.2.Final) started in 0.394s. Listening on: http://localhost:8080
 
-2023-05-03 18:17:48,403 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
-2023-05-03 18:17:48,404 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy-reactive, smallrye-context-propagation, vertx]
+INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
+INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy-reactive, smallrye-context-propagation, vertx]
 ----

--- a/documentation/modules/ROOT/pages/_partials/compile-and-run.adoc
+++ b/documentation/modules/ROOT/pages/_partials/compile-and-run.adoc
@@ -134,5 +134,5 @@ __  ____  __  _____   ___  __ ____  ______
 2023-05-03 18:17:48,400 INFO  [io.quarkus] (Quarkus Main Thread) tutorial-app 1.0-SNAPSHOT on JVM (powered by Quarkus 3.0.1.Final) started in 1.416s. Listening on: http://localhost:8080
 
 2023-05-03 18:17:48,403 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
-2023-05-03 18:17:48,404 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy, smallrye-context-propagation, vertx]
+2023-05-03 18:17:48,404 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy-reactive, smallrye-context-propagation, vertx]
 ----

--- a/documentation/modules/ROOT/pages/_partials/compile-and-run.adoc
+++ b/documentation/modules/ROOT/pages/_partials/compile-and-run.adoc
@@ -131,7 +131,7 @@ __  ____  __  _____   ___  __ ____  ______
  --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
  -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
-2023-05-03 18:17:48,400 INFO  [io.quarkus] (Quarkus Main Thread) tutorial-app 1.0-SNAPSHOT on JVM (powered by Quarkus 3.1.2.Final) started in 1.416s. Listening on: http://localhost:8080
+2023-05-03 18:17:48,400 INFO  [io.quarkus] (Quarkus Main Thread) tutorial-app 1.0-SNAPSHOT on JVM (powered by Quarkus 3.1.2.Final) started in 0.394s. Listening on: http://localhost:8080
 
 2023-05-03 18:17:48,403 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
 2023-05-03 18:17:48,404 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy-reactive, smallrye-context-propagation, vertx]

--- a/documentation/modules/ROOT/pages/_partials/compile-and-run.adoc
+++ b/documentation/modules/ROOT/pages/_partials/compile-and-run.adoc
@@ -131,7 +131,7 @@ __  ____  __  _____   ___  __ ____  ______
  --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
  -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
 --\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
-2023-05-03 18:17:48,400 INFO  [io.quarkus] (Quarkus Main Thread) tutorial-app 1.0-SNAPSHOT on JVM (powered by Quarkus 3.0.1.Final) started in 1.416s. Listening on: http://localhost:8080
+2023-05-03 18:17:48,400 INFO  [io.quarkus] (Quarkus Main Thread) tutorial-app 1.0-SNAPSHOT on JVM (powered by Quarkus 3.1.2.Final) started in 1.416s. Listening on: http://localhost:8080
 
 2023-05-03 18:17:48,403 INFO  [io.quarkus] (Quarkus Main Thread) Profile dev activated. Live Coding activated.
 2023-05-03 18:17:48,404 INFO  [io.quarkus] (Quarkus Main Thread) Installed features: [cdi, resteasy-reactive, smallrye-context-propagation, vertx]

--- a/documentation/modules/ROOT/pages/basics.adoc
+++ b/documentation/modules/ROOT/pages/basics.adoc
@@ -74,7 +74,7 @@ You can stop your running application by issuing a `CTRL+C` in your terminal.
 [.console-output]
 [source,bash]
 ----
-^C2020-05-10 23:11:03,419 INFO  [io.quarkus] (main) tutorial-app stopped in 0.035s
+INFO  [io.quarkus] (main) tutorial-app stopped in 0.035s
 ----
 
 Quarkus was able to stop in just *0.035s*. Fast to start, fast to stop. Fast always!

--- a/documentation/modules/ROOT/pages/basics.adoc
+++ b/documentation/modules/ROOT/pages/basics.adoc
@@ -18,7 +18,7 @@ mvn "io.quarkus:quarkus-maven-plugin:create" \
   -DprojectVersion="1.0-SNAPSHOT" \
   -DclassName="GreetingResource" \
   -Dpath="hello" \
-  -Dextensions="resteasy"
+  -Dextensions="resteasy-reactive"
 cd {project-name}
 ----
 
@@ -35,7 +35,7 @@ Then create the application:
 [source,bash,subs="+macros,+attributes"]
 ----
 quarkus create app \
-  -x resteasy \
+  -x resteasy-reactive \
   com.redhat.developers:tutorial-app:1.0-SNAPSHOT
 cd {project-name}
 ----

--- a/documentation/modules/ROOT/pages/basics.adoc
+++ b/documentation/modules/ROOT/pages/basics.adoc
@@ -49,7 +49,7 @@ IMPORTANT: All the remaining parts of this tutorial assume that you'll be workin
 
 include::ROOT:partial$compile-and-run.adoc[]
 
-Notice how *fast* Quarkus was ready to serve your requests. In this particular example Quarkus only required *0.016s* to start.
+Notice how *fast* Quarkus was ready to serve your requests. In this particular example Quarkus only required *0.394s* to start.
 
 You can open your browser with the url `http://localhost:8080/hello[window="_blank"]` and you should see a response like `hello`.
 
@@ -64,7 +64,7 @@ curl localhost:8080/hello
 [.console-output]
 [source,bash]
 ----
-hello
+Hello from RESTEasy Reactive
 ----
 
 == Stopping the application
@@ -74,10 +74,10 @@ You can stop your running application by issuing a `CTRL+C` in your terminal.
 [.console-output]
 [source,bash]
 ----
-^C2020-05-10 23:11:03,419 INFO  [io.quarkus] (main) tutorial-app stopped in 0.007s
+^C2020-05-10 23:11:03,419 INFO  [io.quarkus] (main) tutorial-app stopped in 0.035s
 ----
 
-Quarkus was able to stop in just *0.007s*. Fast to start, fast to stop. Fast always!
+Quarkus was able to stop in just *0.035s*. Fast to start, fast to stop. Fast always!
 
 == Testing your application
 

--- a/documentation/modules/ROOT/pages/kafka-and-streams.adoc
+++ b/documentation/modules/ROOT/pages/kafka-and-streams.adoc
@@ -195,7 +195,6 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import io.smallrye.mutiny.Multi;
-import org.jboss.resteasy.annotations.SseElementType;
 
 @Path("/beer")
 public class BeerResource {
@@ -224,7 +223,6 @@ public class BeerResource {
 
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
-    @SseElementType(MediaType.APPLICATION_JSON)
     public Multi<PricedBeer> pricedBeers() {
         return pricedBeers.map(s -> JsonbBuilder.create().fromJson(s, PricedBeer.class)) //<2>
                 .ifNoItem().after(Duration.ofSeconds(1)).fail(); //<3>

--- a/documentation/modules/ROOT/pages/panache.adoc
+++ b/documentation/modules/ROOT/pages/panache.adoc
@@ -26,7 +26,7 @@ Maven::
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-mvn quarkus:add-extension -Dextension="quarkus-resteasy-jsonb, quarkus-jdbc-h2, quarkus-hibernate-orm-panache, quarkus-smallrye-openapi"
+mvn quarkus:add-extension -Dextension="quarkus-resteasy-reactive-jsonb, quarkus-jdbc-h2, quarkus-hibernate-orm-panache, quarkus-smallrye-openapi"
 ----
 
 --
@@ -36,7 +36,7 @@ Quarkus CLI::
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-quarkus extension add quarkus-resteasy-jsonb quarkus-jdbc-h2 quarkus-hibernate-orm-panache quarkus-smallrye-openapi
+quarkus extension add quarkus-resteasy-reactive-jsonb quarkus-jdbc-h2 quarkus-hibernate-orm-panache quarkus-smallrye-openapi
 ----
 --
 ====
@@ -45,7 +45,7 @@ quarkus extension add quarkus-resteasy-jsonb quarkus-jdbc-h2 quarkus-hibernate-o
 [.console-output]
 [source,text]
 ----
-✅ Adding extension io.quarkus:quarkus-resteasy-jsonb
+✅ Adding extension io.quarkus:quarkus-resteasy-reactive-jsonb
 ✅ Adding extension io.quarkus:quarkus-smallrye-openapi
 ✅ Adding extension io.quarkus:quarkus-hibernate-orm-panache
 ✅ Adding extension io.quarkus:quarkus-jdbc-h2

--- a/documentation/modules/ROOT/pages/reactive.adoc
+++ b/documentation/modules/ROOT/pages/reactive.adoc
@@ -7,7 +7,7 @@ to online beer database (https://punkapi.com/documentation/v2) to retrieve beer 
 This API does not return all beers at once, so we'll need to navigate through the pages to fetch all the information. 
 Then we're going to filter all the beers with an ABV greater than 15.0 and return all these beers in a Reactive REST endpoint.
 
-== Add the RestEasy Mutiny extension
+== Add the Mutiny extension
 
 Just open a new terminal window, and make sure you’re at the root of your `{project-name}` project, then run:
 
@@ -19,7 +19,7 @@ Maven::
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-mvn quarkus:add-extension -Dextension=quarkus-resteasy-mutiny
+mvn quarkus:add-extension -Dextension=quarkus-mutiny
 ----
 
 --
@@ -29,7 +29,7 @@ Quarkus CLI::
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-quarkus extension add quarkus-resteasy-mutiny
+quarkus extension add quarkus-mutiny
 ----
 --
 ====

--- a/documentation/modules/ROOT/pages/spring.adoc
+++ b/documentation/modules/ROOT/pages/spring.adoc
@@ -14,7 +14,7 @@ Maven::
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-mvn quarkus:add-extension -Dextensions=quarkus-spring-web,quarkus-spring-data-jpa,quarkus-resteasy-jackson
+mvn quarkus:add-extension -Dextensions=quarkus-spring-web,quarkus-spring-data-jpa,quarkus-resteasy-reactive-jackson
 ----
 
 --
@@ -24,7 +24,7 @@ Quarkus CLI::
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-quarkus extension add quarkus-spring-web quarkus-spring-data-jpa quarkus-resteasy-jackson
+quarkus extension add quarkus-spring-web quarkus-spring-data-jpa quarkus-resteasy-reactive-jackson
 ----
 --
 ====
@@ -50,8 +50,8 @@ quarkus extension add quarkus-spring-web quarkus-spring-data-jpa quarkus-resteas
 ----
 
 IMPORTANT: The `quarkus-spring-web` extension requires `quarkus-resteasy-jackson` or `quarkus-resteasy-reactive-jackson`.
-In order to be conservative with the amount of dependencies, please change in `pom.xml` the extension `quarkus-reasteasy` 
-to `quarkus-resteasy-jackson`.
+In order to be conservative with the amount of dependencies, please change in `pom.xml` the extension `quarkus-reasteasy-reactive` 
+to `quarkus-resteasy-reactive-jackson`.
 
 
 == Create a Spring Data Repository for Fruit


### PR DESCRIPTION
The Quarkus RestEasy Classic extension is no longer the default. It should be the RestEasy Reactive extension