### PR TITLE
Match tutorial-tools version between pull and run

### DIFF
--- a/documentation/modules/ROOT/pages/01_setup.adoc
+++ b/documentation/modules/ROOT/pages/01_setup.adoc
@@ -93,7 +93,7 @@ cd quarkus-tutorial
 mkdir work
 docker run -ti -p 8080:8080 -v `pwd`/work:/work \
   -v `mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout`:/opt/developer/.m2/repository \
-  --rm quay.io/rhdevelopers/tutorial-tools:0.0.7 bash
+  --rm quay.io/rhdevelopers/tutorial-tools:latest bash
 
 # -p will map Quarkus running in the container to your host port
 # -v `pwd`... will map the host work subdirectory to the container /work directory, this is where you will create your application


### PR DESCRIPTION
Match docker run tutorial-tools version with the docker pull command so that we don't end up with two images:

"docker pull tutorial-tools"  will pull latest image, while  "docker run ... tutorial-tools:0.0.7" will always pull 0.0.7.