### PR TITLE
"Fault Tolerance" "SwapiService" path and error handling details

### DIFF
--- a/documentation/modules/ROOT/pages/09_fault-tolerance.adoc
+++ b/documentation/modules/ROOT/pages/09_fault-tolerance.adoc
@@ -57,7 +57,7 @@ import com.redhat.developers.Swapi.Results;
 @RegisterRestClient
 public interface SwapiService {
     @GET
-    @Path("/films/")
+    @Path("/films/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @Retry(maxRetries = 3, delay = 2000)
     public Swapi getFilmById(@PathParam("id") String id);
@@ -142,11 +142,9 @@ public interface SwapiService {
 
 ----
 
-Now in case of any error, 3 retries are done automatically, waiting for 2 seconds between retries.
+Now the request will be attempted for 2 seconds. If there is an error, then the fallback method is executed.
 
-If the error persists, then the fallback method is executed.
-
-Now after waiting for 6 seconds (3 retries x 2 seconds), an empty object is sent instead of an exception.
+Now after waiting for 2 seconds, an empty object is sent instead of an exception.
 
 == Invoke the endpoint with Retry and Fallback
 


### PR DESCRIPTION
When going through this guide, I found a couple of elements. I made the below proposed changes. Feel free to add onto or update my proposals.

**Change 1 - "Fault Tolerance | Add Retry to SwapiService" Correct `/films/{id}` Path**

Updating the path to `/films/{id}` causes the program to execute correctly. Previously there would be an error.
```
public interface SwapiService {
    @GET
    @Path("/films/{id}") // The path was previously "/films/", causing an error.
    @Produces(MediaType.APPLICATION_JSON)
    @Retry(maxRetries = 3, delay = 2000)
    public Swapi getFilmById(@PathParam("id") String id);
}
```
In this section, "Add Retry to SwapiService," I believe the program should execute correctly. This next section asks the user to run the code. It states that there should be "No change from calls done previously."

**Change 2 - "Fault Tolerance | Add Fallback to Swapi Service" Error Description Using Timeout**

In this section's code, timeout replaces retry.

```
@GET
@Path("/films/{id}")
@Produces(MediaType.APPLICATION_JSON)
@Timeout(value = 2000L) // This replaces "@Retry(maxRetries = 3, delay = 2000)."
@Fallback(SwapiFallback.class)
public Swapi getFilmById(@PathParam("id") String id);
```
I updated the error description to state that the error handling will be based on a timeout of 2 seconds. Since there is no longer code involving 3 retries, I removed that description.