### PR TITLE
Update "Health Check" URLs to swapi.info

### DIFF
--- a/documentation/modules/ROOT/pages/10_health.adoc
+++ b/documentation/modules/ROOT/pages/10_health.adoc
@@ -127,7 +127,7 @@ public class CustomHealthCheck {
 
     @Readiness //<1>
     HealthCheck checkURL() {
-        return new UrlHealthCheck(externalURL+"/api/films/") //<2>
+        return new UrlHealthCheck(externalURL+"/films/") //<2>
                 .name("ExternalURL health check").requestMethod(HttpMethod.GET).statusCode(200);
     }
 
@@ -160,7 +160,7 @@ curl -w '\n' localhost:8080/health
             "name": "ExternalURL health check",
             "status": "UP",
             "data": {
-                "host": "GET https://swapi.dev/api/films"
+                "host": "GET https://swapi.info/api/films"
             }
         },
         {
@@ -219,7 +219,7 @@ curl -w '\n' localhost:8080/health/ready
             "name": "ExternalURL health check",
             "status": "UP",
             "data": {
-                "host": "GET https://swapi.dev/api/films"
+                "host": "GET https://swapi.info/api/films"
             }
         },
         {


### PR DESCRIPTION
Thank you for the quick approval last time!

This is another minor proposal for the "[Cloud Native | Health Check](https://redhat-developer-demos.github.io/quarkus-tutorial/quarkus-tutorial/10_health.html)" section. Again, feel free to make further changes.

```
  @Readiness 
  HealthCheck checkURL() {

     // The external URL is "https://swapi.info/api".
     // So I changed this from "/api/films/" to "/films/".

      return new UrlHealthCheck(externalURL+"/films/")
              .name("ExternalURL health check").requestMethod(HttpMethod.GET).statusCode(200);
  }
```
As noted above, [the externalURL](https://redhat-developer-demos.github.io/quarkus-tutorial/quarkus-tutorial/08_rest-client.html#_configure_rest_client_properties) is "https://swapi.info/api". Therefore I made a small update in "[Add a custom readiness probe](https://redhat-developer-demos.github.io/quarkus-tutorial/quarkus-tutorial/10_health.html#_add_a_custom_readiness_probe)."

In addition, I updated the results of the health probes to be https://swapi.info/api/films.