### PR TITLE
Migrate tutorial from swapi.info/swapi.dev to swapi.build

### DIFF
--- a/apps/tutorial_app/src/main/resources/application.properties
+++ b/apps/tutorial_app/src/main/resources/application.properties
@@ -17,7 +17,7 @@ quarkus.container-image.name=tutorial-app
 quarkus.container-image.tag=1.0-SNAPSHOT
 quarkus.kubernetes.service-type=load-balancer
 
-quarkus.rest-client."com.redhat.developers.SwapiService".url=https://swapii.dev
+quarkus.rest-client."com.redhat.developers.SwapiService".url=https://swapii.build
 quarkus.rest-client.logging.scope=request-response
 quarkus.rest-client.logging.body-limit=1024
 quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG

--- a/documentation/modules/ROOT/pages/08_rest-client.adoc
+++ b/documentation/modules/ROOT/pages/08_rest-client.adoc
@@ -2,7 +2,7 @@
 
 A typical scenario in a Microservices architecture is the remote invocation of remote REST HTTP endpoints. Quarkus provides a typed REST client that follows the  https://github.com/eclipse/microprofile-rest-client[MicroProfile REST Client, window=_blank] specification.
 
-Let's create a REST client that accesses https://swapi.info[window=_blank] to get additional information about Movies. The endpoint we're interested in is this one:
+Let's create a REST client that accesses https://swapi.build[window=_blank] to get additional information about Movies. The endpoint we're interested in is this one:
 
 * `api/films/\{id\}`, which returns specific info about the given movie.
 
@@ -17,56 +17,56 @@ Let's create a REST client that accesses https://swapi.info[window=_blank] to ge
 	"producer": "Gary Kurtz, Rick McCallum",
 	"release_date": "1977-05-25",
 	"characters": [
-		"https://swapi.info/api/people/1",
-		"https://swapi.info/api/people/2",
-		"https://swapi.info/api/people/3",
-		"https://swapi.info/api/people/4",
-		"https://swapi.info/api/people/5",
-		"https://swapi.info/api/people/6",
-		"https://swapi.info/api/people/7",
-		"https://swapi.info/api/people/8",
-		"https://swapi.info/api/people/9",
-		"https://swapi.info/api/people/10",
-		"https://swapi.info/api/people/12",
-		"https://swapi.info/api/people/13",
-		"https://swapi.info/api/people/14",
-		"https://swapi.info/api/people/15",
-		"https://swapi.info/api/people/16",
-		"https://swapi.info/api/people/18",
-		"https://swapi.info/api/people/19",
-		"https://swapi.info/api/people/81"
+		"https://swapi.build/api/people/1",
+		"https://swapi.build/api/people/2",
+		"https://swapi.build/api/people/3",
+		"https://swapi.build/api/people/4",
+		"https://swapi.build/api/people/5",
+		"https://swapi.build/api/people/6",
+		"https://swapi.build/api/people/7",
+		"https://swapi.build/api/people/8",
+		"https://swapi.build/api/people/9",
+		"https://swapi.build/api/people/10",
+		"https://swapi.build/api/people/12",
+		"https://swapi.build/api/people/13",
+		"https://swapi.build/api/people/14",
+		"https://swapi.build/api/people/15",
+		"https://swapi.build/api/people/16",
+		"https://swapi.build/api/people/18",
+		"https://swapi.build/api/people/19",
+		"https://swapi.build/api/people/81"
 	],
 	"planets": [
-		"https://swapi.info/api/planets/1",
-		"https://swapi.info/api/planets/2",
-		"https://swapi.info/api/planets/3"
+		"https://swapi.build/api/planets/1",
+		"https://swapi.build/api/planets/2",
+		"https://swapi.build/api/planets/3"
 	],
 	"starships": [
-		"https://swapi.info/api/starships/2",
-		"https://swapi.info/api/starships/3",
-		"https://swapi.info/api/starships/5",
-		"https://swapi.info/api/starships/9",
-		"https://swapi.info/api/starships/10",
-		"https://swapi.info/api/starships/11",
-		"https://swapi.info/api/starships/12",
-		"https://swapi.info/api/starships/13"
+		"https://swapi.build/api/starships/2",
+		"https://swapi.build/api/starships/3",
+		"https://swapi.build/api/starships/5",
+		"https://swapi.build/api/starships/9",
+		"https://swapi.build/api/starships/10",
+		"https://swapi.build/api/starships/11",
+		"https://swapi.build/api/starships/12",
+		"https://swapi.build/api/starships/13"
 	],
 	"vehicles": [
-		"https://swapi.info/api/vehicles/4",
-		"https://swapi.info/api/vehicles/6",
-		"https://swapi.info/api/vehicles/7",
-		"https://swapi.info/api/vehicles/8"
+		"https://swapi.build/api/vehicles/4",
+		"https://swapi.build/api/vehicles/6",
+		"https://swapi.build/api/vehicles/7",
+		"https://swapi.build/api/vehicles/8"
 	],
 	"species": [
-		"https://swapi.info/api/species/1",
-		"https://swapi.info/api/species/2",
-		"https://swapi.info/api/species/3",
-		"https://swapi.info/api/species/4",
-		"https://swapi.info/api/species/5"
+		"https://swapi.build/api/species/1",
+		"https://swapi.build/api/species/2",
+		"https://swapi.build/api/species/3",
+		"https://swapi.build/api/species/4",
+		"https://swapi.build/api/species/5"
 	],
 	"created": "2014-12-10T14:23:31.880000Z",
 	"edited": "2014-12-20T19:49:45.256000Z",
-	"url": "https://swapi.info/api/films/1"
+	"url": "https://swapi.build/api/films/1"
 }
 ----
 
@@ -121,7 +121,7 @@ Notice in the logs how Quarkus is reloading and the `rest-client-jackson` extens
 
 == Create Swapi POJO
 
-We need to create a POJO object that is used to unmarshal a JSON message from http://swapi.dev[window=_blank].
+We need to create a POJO object that is used to unmarshal a JSON message from https://swapi.build[window=_blank].
 
 Create a new `Swapi` Java class in `src/main/java` in the `com.redhat.developers` package with the following contents:
 
@@ -231,7 +231,7 @@ Add the following properties to your `application.properties` in `src/main/resou
 [.console-input]
 [source,properties]
 ----
-quarkus.rest-client."com.redhat.developers.SwapiService".url=https://swapi.info/api
+quarkus.rest-client."com.redhat.developers.SwapiService".url=https://swapi.build/api
 ----
 
 == Create MovieDTO

--- a/documentation/modules/ROOT/pages/09_fault-tolerance.adoc
+++ b/documentation/modules/ROOT/pages/09_fault-tolerance.adoc
@@ -91,7 +91,7 @@ curl -w '\n' localhost:8080/movie?year=1980
 ]
 ----
 
-No change from calls done previously, but now change the https://swapi.dev url in your application properties to https://swapii.dev (or some other random url that won't resolve).
+No change from calls done previously, but now change the https://swapi.build url in your application properties to https://swapii.build (or some other random url that won't resolve).
 
 Run the following command again:
 
@@ -101,7 +101,7 @@ Run the following command again:
 curl -w '\n' localhost:8080/movie?year=1980
 ----
 
-Now after waiting 6 seconds (3 retries x 2 seconds), the next exception is thrown `java.net.UnknownHostException: swapii.dev`.
+Now after waiting 6 seconds (3 retries x 2 seconds), the next exception is thrown `java.net.UnknownHostException: swapii.build`.
 
 == Add Fallback to Swapi Service
 
@@ -228,7 +228,7 @@ Run the following command at least 5 times (without network connectivity):
 curl -w '\n' localhost:8080/movie?year=1980
 ----
 
-The output changes from `java.net.UnknownHostException: swapii.dev` (or any other network exception) in the first calls to `org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException: getMovieByTitle` when the circuit is opened.
+The output changes from `java.net.UnknownHostException: swapii.build` (or any other network exception) in the first calls to `org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException: getMovieByTitle` when the circuit is opened.
 
 The big difference between the first exception and the second one is that the first one occurs because the circuit is closed while the system is trying to reach the host, while in the second one, the circuit is closed and the exception is thrown automatically without trying to reach the host.
 

--- a/documentation/modules/ROOT/pages/10_health.adoc
+++ b/documentation/modules/ROOT/pages/10_health.adoc
@@ -102,7 +102,7 @@ Some extensions may provide default health checks, including that the extension 
 For example, quarkus-agroal (which is used to manage Quarkus datasources) automatically registers a readiness health check that will validate each datasource.
 
 Since the readiness of the database is already assessed just by adding those extensions, we should look into defining health checks for other dependencies that we have.
-As we depend on the availability of https://swapi.dev, let's create a new `ReadinessProbe` to assess its availability prior to using it.
+As we depend on the availability of https://swapi.build, let's create a new `ReadinessProbe` to assess its availability prior to using it.
 
 We will define a new Java class in `src/main/java` in the `com.redhat.developers` package with the following contents:
 
@@ -128,7 +128,7 @@ public class CustomHealthCheck {
     @Readiness //<1>
     HealthCheck checkURL() {
         return new UrlHealthCheck(externalURL+"/films/") //<2>
-                .name("ExternalURL health check").requestMethod(HttpMethod.GET).statusCode(200);
+                .name("ExternalURL health check").requestMethod(HttpMethod.GET).statusCode(202);
     }
 
 }
@@ -160,7 +160,7 @@ curl -w '\n' localhost:8080/health
             "name": "ExternalURL health check",
             "status": "UP",
             "data": {
-                "host": "GET https://swapi.info/api/films"
+                "host": "GET https://swapi.build/api/films"
             }
         },
         {
@@ -219,7 +219,7 @@ curl -w '\n' localhost:8080/health/ready
             "name": "ExternalURL health check",
             "status": "UP",
             "data": {
-                "host": "GET https://swapi.info/api/films"
+                "host": "GET https://swapi.build/api/films"
             }
         },
         {


### PR DESCRIPTION
Closes #179.

## Summary

Migrates every Star Wars API reference in the tutorial (docs + `tutorial_app`) from `swapi.info` / `swapi.dev` to the new `https://swapi.build/api` service that the issue points to.

## Changes

| File | What changed |
|---|---|
| `documentation/modules/ROOT/pages/08_rest-client.adoc` | All `https://swapi.info/...` URLs (example JSON, prose, `application.properties` snippet) now use `https://swapi.build/...`. The "Create Swapi POJO" paragraph's `http://swapi.dev` reference also switched to `https://swapi.build`. |
| `documentation/modules/ROOT/pages/09_fault-tolerance.adoc` | "Change the https://swapi.dev url... to https://swapii.dev" is now "https://swapi.build... to https://swapii.build". The expected `UnknownHostException` output was updated to match. |
| `documentation/modules/ROOT/pages/10_health.adoc` | `https://swapi.dev` in prose and `https://swapi.info/api/films` in the two expected health-endpoint JSON responses are now `swapi.build`. See note below on status code. |
| `apps/tutorial_app/src/main/resources/application.properties` | `https://swapii.dev` -> `https://swapii.build` so the fault-tolerance chapter's intentionally-broken URL stays consistent with the new base domain. |

## Notes for reviewers

- `swapi.build` currently responds **`202 Accepted`** to `GET /api/films/` instead of `200 OK`. The readiness probe in `10_health.adoc` hard-codes `.statusCode(200)`, so the tutorial's health check would always fail against the new backend without this change. I updated that one value to `202`. If the swapi.build team plans to move to `200`, this line should be updated back at that time.
- I verified each of the six URIs touched resolves against `swapi.build` (`HTTP/2 202` with a JSON body matching the shape shown in the tutorial).
- The `swapi.build` JSON preserves the `swapi.info`-style endpoints (no trailing slash, no endpoint renames), so no payload/POJO changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)