### PR TITLE
For Podman AI, change "SessionScoped" to "ApplicationScoped"

### DIFF
--- a/documentation/modules/ROOT/pages/21_podman_ai.adoc
+++ b/documentation/modules/ROOT/pages/21_podman_ai.adoc
@@ -105,10 +105,10 @@ package com.redhat.developers;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import io.quarkiverse.langchain4j.RegisterAiService;
-import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @RegisterAiService()
-@SessionScoped
+@ApplicationScoped
 public interface Assistant {
 
     @SystemMessage({


### PR DESCRIPTION
In "Working with Podman Desktop AI => [Create the AI service](https://redhat-developer-demos.github.io/quarkus-tutorial/quarkus-tutorial/21_podman_ai.html#_create_the_ai_service)," I changed the `SessionScoped` to `ApplicationScoped`.

The `SessionScoped` gave the below error.

<img width="1710" height="1107" alt="Screenshot 2026-04-21 at 16 11 22" src="https://github.com/user-attachments/assets/3cb06d17-45ac-428a-94de-2bb634908cff" />
--------- ---------- ---------- ---------- ----------

Therefore, based on AI, I updated the scope to `ApplicationScoped`.

<img width="775" height="581" alt="Screenshot 2026-04-21 at 16 19 01" src="https://github.com/user-attachments/assets/8059820c-c212-449a-8224-c4fbbada1201" />


Again, feel free to make modifications to my change. Another possibility was to add the extension "Quarkus Undertow."  However, ChatGPT didn't like "Undertow" as "it introduces unnecessary complexity."